### PR TITLE
Add support for user to specify the height for the circle

### DIFF
--- a/polycircles/polycircles.py
+++ b/polycircles/polycircles.py
@@ -1,7 +1,4 @@
 from geographiclib import geodesic
-import crange
-from itertools import cycle
-
 
 class Shape(object):
     """Common operations for shapes"""


### PR DESCRIPTION
Add support for user to specify the height for the circle, and for example, use the result for to_lat_lon_height() as the outerboundary for the circle.